### PR TITLE
Remove nsp check to fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "start": "node .",
-    "posttest": "npm run lint && nsp check"
+    "posttest": "npm run lint"
   },
   "dependencies": {
     "compression": "^1.0.3",
@@ -19,8 +19,7 @@
   },
   "devDependencies": {
     "eslint": "^2.13.1",
-    "eslint-config-loopback": "^4.0.0",
-    "nsp": "^2.1.0"
+    "eslint-config-loopback": "^4.0.0"
   },
   "repository": {
     "type": "",


### PR DESCRIPTION
nsp is no longer supported and fails with the following error:

    getaddrinfo ENOTFOUND api.nodesecurity.io api.nodesecurity.io:443

Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- see also https://github.com/strongloop/loopback-sandbox/pull/26

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)